### PR TITLE
Fix GitHub Pages base path

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -4,4 +4,5 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  base: process.env.NODE_ENV === 'production' ? '/Edelmetalldepot/' : '/',
 })


### PR DESCRIPTION
## Summary
- configure Vite to use the repository subdirectory as the base path during production builds so the site loads on GitHub Pages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d23c8fa6148327a7bc836ff5b8fa8e