### PR TITLE
Ensure production build targets docs directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build --outDir docs --emptyOutDir",
     "lint": "eslint .",
     "preview": "vite preview"
   },


### PR DESCRIPTION
## Summary
- update the build script so Vite writes its output to the docs folder by default
- empty the docs folder before each build to avoid stale assets

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d260c0bbe08327a78925d92cfc9faf